### PR TITLE
Fix favicon metadata for search results

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Pricehammer logo">
+  <defs>
+    <linearGradient id="hammerGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="#0b1220" />
+  <path fill="url(#hammerGradient)" d="M18 18h14a8 8 0 0 1 0 16H26v12h-8zm8 6v4h6a2 2 0 0 0 0-4z" />
+  <path fill="#f8fafc" d="M34 20h12l4 6h-12z" />
+  <path fill="#f8fafc" d="M38 26h12v18a4 4 0 0 1-4 4H38z" opacity=".8" />
+</svg>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,19 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "Pricehammer",
+  "short_name": "Pricehammer",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#0b1220",
+  "background_color": "#0b1220",
+  "display": "standalone"
+}


### PR DESCRIPTION
## Summary
- add a dedicated SVG favicon so search engines pick up the site logo
- update the web manifest with brand metadata and theme colors to match the favicon assets

## Testing
- npm run lint *(fails: existing repo lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68df9b73b4c88330845ccad1b8d1172f