### PR TITLE
Add SEO-focused Warhammer prices landing page

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,4 @@
 User-agent: *
-Allow: /favicon.ico
-Allow: /favicon.svg
-Allow: /apple-touch-icon.png
-Allow: /logo/
+Allow: /
+
 Sitemap: https://pricehammer.xyz/sitemap.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,22 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "Pricehammer",
+  "short_name": "Pricehammer",
+  "description": "Compare Warhammer 40,000 and Age of Sigmar prices across Australian retailers with live updates from PriceHammer.",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#0b1220",
+  "background_color": "#0b1220",
+  "start_url": "/warhammer-prices",
+  "scope": "/",
+  "display": "standalone"
+}

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://pricehammer.xyz/</loc>
+    <lastmod>2025-10-03</lastmod>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://pricehammer.xyz/warhammer-prices</loc>
+    <lastmod>2025-10-03</lastmod>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://pricehammer.xyz/about</loc>
+    <lastmod>2025-10-03</lastmod>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://pricehammer.xyz/contact</loc>
+    <lastmod>2025-10-03</lastmod>
+    <priority>0.6</priority>
+  </url>
+</urlset>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,11 +1,14 @@
 {
   "name": "Pricehammer",
   "short_name": "Pricehammer",
+  "description": "Compare Warhammer 40,000 and Age of Sigmar prices across Australian retailers with live updates from PriceHammer.",
   "icons": [
-    { "src": "/logo/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/logo/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
   ],
-  "theme_color": "#0ea5e9",
-  "background_color": "#0ea5e9",
+  "theme_color": "#0b1220",
+  "background_color": "#0b1220",
+  "start_url": "/warhammer-prices",
+  "scope": "/",
   "display": "standalone"
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,2 +1,17 @@
+import type { Metadata } from "next";
 import { About } from "@/components/About";
-export default function AboutPage() { return <About />; }
+
+const description =
+  "Learn how PriceHammer tracks Australian Warhammer prices, the data sources we use, and the mission behind the hobby project.";
+
+export const metadata: Metadata = {
+  title: "About PriceHammer",
+  description,
+  alternates: {
+    canonical: "/about",
+  },
+};
+
+export default function AboutPage() {
+  return <About />;
+}

--- a/src/app/components/About.tsx
+++ b/src/app/components/About.tsx
@@ -3,16 +3,22 @@ export function About() {
     <div className="max-w-2xl mx-auto space-y-4">
       <h1 className="text-3xl font-display font-bold">About</h1>
       <p className="text-slate-700 dark:text-slate-300">
-        PriceHammer helps you look up Games Workshop products and compare prices across retailers.
-        Data is curated and updated periodically.
+        PriceHammer is a hobby-built search tool that helps Australian Warhammer fans compare Games Workshop product prices
+        across local retailers. Data is curated and updated regularly so you can see the latest deals before limited stock
+        disappears.
       </p>
       <p>
-        Currently data only covers the OCE region, with a few select LGS'.
+        Currently data only covers the OCE region, with a curated list of local game stores.
       </p>
       <p className="text-slate-700 dark:text-slate-300">
         This is a hobby project; not affiliated with Games Workshop. If you find bugs or have suggestions,
         please reach out via email below.
       </p>
+      <ul className="list-disc space-y-2 pl-5 text-slate-700 dark:text-slate-300">
+        <li>Track the lowest AUD price for Warhammer 40,000, Age of Sigmar, and Kill Team kits.</li>
+        <li>Filter by faction, category, or game system to plan your next army list or campaign.</li>
+        <li>Report inaccurate listings so the community can benefit from clean, trusted pricing data.</li>
+      </ul>
     </div>
   );
 }

--- a/src/app/components/ContactStatic.tsx
+++ b/src/app/components/ContactStatic.tsx
@@ -3,7 +3,8 @@ export function ContactStatic() {
     <div className="max-w-2xl mx-auto space-y-4">
       <h1 className="text-3xl font-display font-bold">Contact</h1>
       <p className="text-slate-700 dark:text-slate-300">
-        Found a bug or missing product? Email me:
+        Have a Warhammer retailer you would like tracked or spotted a price mismatch? Reach out so we can keep the Australian
+        comparison tool accurate:
       </p>
       <p>
         <a

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -6,8 +6,11 @@ export function Footer() {
   return (
     <footer className="border-t bg-white/40 backdrop-blur dark:bg-slate-900/80">
       <div className="max-w-screen-xl mx-auto px-3 sm:px-6 lg:px-8 py-5 flex flex-col sm:flex-row items-center justify-between gap-4">
-        <div className="text-sm text-slate-500">
-          © {new Date().getFullYear()} PriceHammer
+        <div className="text-sm text-slate-500 space-y-1">
+          <p>© {new Date().getFullYear()} PriceHammer</p>
+          <p className="max-w-xs text-left">
+            Australian Warhammer price comparison tool for Games Workshop miniatures.
+          </p>
         </div>
 
         {/* Middle: nav */}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -37,21 +37,21 @@ export function Header() {
     <header className="sticky top-0 z-40 border-b bg-white/90 backdrop-blur">
       <div className="max-w-screen-xl mx-auto px-3 sm:px-6 lg:px-8 h-12 sm:h-14 flex items-center justify-between gap-2">
         {/* Brand */}
-        <Link href="/" className="inline-flex items-center gap-2 font-semibold text-slate-900">
+        <Link href="/warhammer-prices" className="inline-flex items-center gap-2 font-semibold text-slate-900">
           {/* you can swap to next/image later if you want */}
           <img
             className="rounded-md"
             src="/logo/logo.png"
             width={50}
             height={50}
-            alt="Logo"
+            alt="PriceHammer logo"
           />
           <span className="text-base sm:text-lg">PriceHammer</span>
         </Link>
 
         {/* Nav (scrolls horizontally on mobile if needed) */}
         <nav className="flex items-center gap-2 overflow-x-auto no-scrollbar -mx-2 px-2">
-          <NavItem href="/" exact>
+          <NavItem href="/warhammer-prices" exact>
             🔎 Product Lookup
           </NavItem>
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,2 +1,17 @@
+import type { Metadata } from "next";
 import { ContactStatic } from "@/components/ContactStatic";
-export default function ContactPage() { return <ContactStatic />; }
+
+const description =
+  "Contact the PriceHammer team to report incorrect Warhammer prices, request new Australian stores, or share feedback.";
+
+export const metadata: Metadata = {
+  title: "Contact PriceHammer",
+  description,
+  alternates: {
+    canonical: "/contact",
+  },
+};
+
+export default function ContactPage() {
+  return <ContactStatic />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 // app/layout.tsx
 import type { Metadata, Viewport } from "next";
+import Script from "next/script";
 import "./globals.css";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
@@ -14,43 +15,101 @@ const sans = Inter({
   variable: "--font-sans",
 });
 
+const metadataBase = new URL("https://pricehammer.xyz");
+
+const primaryDescription =
+  "Compare Warhammer 40,000 and Age of Sigmar prices from Australian hobby stores. Track savings, find stock quickly, and stay ahead of Games Workshop price rises with PriceHammer.";
+
 export const metadata: Metadata = {
-  title: "Pricehammer",
-  description: "Get the best Warhammer prices in Australia.",
+  metadataBase,
+  title: {
+    default: "Compare Warhammer Prices in Australia",
+    template: "%s | PriceHammer",
+  },
+  description: primaryDescription,
+  keywords: [
+    "Warhammer prices",
+    "Games Workshop deals",
+    "Warhammer 40K Australia",
+    "Age of Sigmar discounts",
+    "miniature wargaming price comparison",
+  ],
+  authors: [{ name: "PriceHammer" }],
+  creator: "PriceHammer",
+  publisher: "PriceHammer",
   icons: {
     icon: [
-      { url: "/favicon.svg", type: "image/svg+xml" },
-      { url: "/favicon-16x16.png", type: "image/png", sizes: "16x16" },
-      { url: "/favicon-32x32.png", type: "image/png", sizes: "32x32" },
       { url: "/favicon.ico" },
+      { url: "/favicon-32x32.png", type: "image/png", sizes: "32x32" },
+      { url: "/favicon-16x16.png", type: "image/png", sizes: "16x16" },
+      { url: "/android-chrome-192x192.png", type: "image/png", sizes: "192x192" },
+      { url: "/android-chrome-512x512.png", type: "image/png", sizes: "512x512" },
     ],
     apple: [{ url: "/apple-touch-icon.png", sizes: "180x180", type: "image/png" }],
     shortcut: ["/favicon.ico"],
   },
   manifest: "/site.webmanifest",
-  // ❌ themeColor must not be here
+  alternates: {
+    canonical: "/warhammer-prices",
+  },
+  openGraph: {
+    type: "website",
+    url: "/warhammer-prices",
+    title: "Compare Warhammer Prices in Australia | PriceHammer",
+    description: primaryDescription,
+    siteName: "PriceHammer",
+    locale: "en_AU",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Compare Warhammer Prices in Australia | PriceHammer",
+    description: primaryDescription,
+    creator: "@pricehammer",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+  category: "shopping",
 };
 
-// ✅ move themeColor into a separate viewport export
 export const viewport: Viewport = {
-  // single color:
-  // themeColor: "#0ea5e9",
-
-  // or media-aware colors:
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#ffffff" },
-    { media: "(prefers-color-scheme: dark)",  color: "#0b1220" },
+    { media: "(prefers-color-scheme: dark)", color: "#0b1220" },
   ],
-  // (optional) other viewport bits if you want:
-  // width: "device-width",
-  // initialScale: 1,
-  // colorScheme: "light dark",
-  // viewportFit: "cover",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${sans.variable} ${display.variable}`}>
+      <head>
+        <Script id="ld-json-website" type="application/ld+json" strategy="beforeInteractive">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            name: "PriceHammer",
+            url: `${metadataBase.origin}/warhammer-prices`,
+            description: primaryDescription,
+            inLanguage: "en-AU",
+            potentialAction: {
+              "@type": "SearchAction",
+              target: {
+                "@type": "EntryPoint",
+                urlTemplate: `${metadataBase.origin}/warhammer-prices?search={search_term_string}`,
+              },
+              "query-input": "required name=search_term_string",
+            },
+          })}
+        </Script>
+      </head>
       <body className="min-h-dvh bg-scroll md:bg-fixed bg-cover bg-center app-bg">
         <div className="min-h-dvh flex flex-col bg-white/60 dark:bg-black/70 backdrop-blur-sm">
           <Header />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,6 @@
 // src/app/page.tsx
-"use client";
-import dynamic from "next/dynamic";
-
-// If ProductLookup is a **named** export:
-const ProductLookup = dynamic(
-  () => import("@/components/ProductLookup").then(m => m.ProductLookup),
-  { ssr: false }
-);
-
-// If it's a **default** export, use:
-// const ProductLookup = dynamic(() => import("@/components/ProductLookup"), { ssr:false });
+import { redirect } from "next/navigation";
 
 export default function HomePage() {
-  return <ProductLookup />;
+  redirect("/warhammer-prices");
 }

--- a/src/app/warhammer-prices/page.tsx
+++ b/src/app/warhammer-prices/page.tsx
@@ -1,0 +1,111 @@
+import type { Metadata } from "next";
+import { ProductLookup } from "@/components/ProductLookup";
+
+const pageDescription =
+  "Instantly compare Games Workshop prices from Australian retailers, spot stock availability, and find the best Warhammer deals before you buy.";
+
+export const metadata: Metadata = {
+  title: "Warhammer Price Comparison in Australia",
+  description: pageDescription,
+  alternates: {
+    canonical: "/warhammer-prices",
+  },
+  openGraph: {
+    title: "Warhammer Price Comparison in Australia | PriceHammer",
+    description: pageDescription,
+    url: "/warhammer-prices",
+  },
+  twitter: {
+    title: "Warhammer Price Comparison in Australia | PriceHammer",
+    description: pageDescription,
+  },
+};
+
+export default function WarhammerPricesPage() {
+  return (
+    <div className="space-y-12">
+      <section className="space-y-6 text-center sm:text-left">
+        <p className="inline-flex items-center gap-2 rounded-full bg-amber-100 px-4 py-1 text-sm font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-200">
+          🇦🇺 Australian Warhammer price tracker
+        </p>
+        <h1 className="text-4xl font-display font-bold text-slate-900 dark:text-white">
+          Find the best Warhammer deals across Australia
+        </h1>
+        <p className="mx-auto max-w-3xl text-lg text-slate-700 dark:text-slate-300">
+          PriceHammer monitors Games Workshop products from trusted Australian hobby stores so you can compare prices, confirm
+          stock availability, and build your army for less. Search by product name, faction, or game system to discover the
+          cheapest way to expand your collection.
+        </p>
+        <ul className="mx-auto grid max-w-3xl gap-3 text-left text-slate-700 dark:text-slate-300 sm:grid-cols-2">
+          <li className="flex items-start gap-2 rounded-lg border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/50">
+            <span className="mt-1 text-emerald-500">✔</span>
+            <span>
+              Compare live prices for Warhammer 40,000, Age of Sigmar, Kill Team, and more across independent Australian
+              retailers.
+            </span>
+          </li>
+          <li className="flex items-start gap-2 rounded-lg border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/50">
+            <span className="mt-1 text-emerald-500">✔</span>
+            <span>Filter by faction or unit type to quickly surface the products that fit your next army list.</span>
+          </li>
+          <li className="flex items-start gap-2 rounded-lg border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/50">
+            <span className="mt-1 text-emerald-500">✔</span>
+            <span>Highlight the lowest AUD price available today and jump directly to the store to secure the deal.</span>
+          </li>
+          <li className="flex items-start gap-2 rounded-lg border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/50">
+            <span className="mt-1 text-emerald-500">✔</span>
+            <span>Regular data refreshes keep listings relevant so you never miss a limited stock restock or discount.</span>
+          </li>
+        </ul>
+      </section>
+
+      <section aria-labelledby="lookup-heading" className="space-y-4">
+        <div className="space-y-2 text-center sm:text-left">
+          <h2 id="lookup-heading" className="text-2xl font-display font-semibold text-slate-900 dark:text-white">
+            Search the live price database
+          </h2>
+          <p className="max-w-2xl text-base text-slate-600 dark:text-slate-300">
+            Enter a product name, select a faction, or switch between game systems to surface the best available prices. Sort
+            results by featured deals, lowest price, or unit points to plan your next purchase with confidence.
+          </p>
+        </div>
+        <ProductLookup />
+      </section>
+
+      <section aria-labelledby="faq-heading" className="space-y-4">
+        <h2 id="faq-heading" className="text-2xl font-display font-semibold text-slate-900 dark:text-white">
+          Frequently asked questions
+        </h2>
+        <div className="space-y-3">
+          <details className="group rounded-lg border border-slate-200 bg-white/80 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <summary className="cursor-pointer text-lg font-medium text-slate-800 transition-colors group-open:text-emerald-600 dark:text-slate-200">
+              Where do the prices come from?
+            </summary>
+            <p className="mt-2 text-slate-700 dark:text-slate-300">
+              We track publicly listed prices from leading Australian hobby stores and refresh the listings regularly. Each
+              product links directly to the retailer so you can verify stock before purchasing.
+            </p>
+          </details>
+          <details className="group rounded-lg border border-slate-200 bg-white/80 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <summary className="cursor-pointer text-lg font-medium text-slate-800 transition-colors group-open:text-emerald-600 dark:text-slate-200">
+              How can I request a store or product to be added?
+            </summary>
+            <p className="mt-2 text-slate-700 dark:text-slate-300">
+              Use the contact form to suggest new retailers or Games Workshop releases. Community feedback helps prioritise the
+              next data imports and ensures regional coverage stays accurate.
+            </p>
+          </details>
+          <details className="group rounded-lg border border-slate-200 bg-white/80 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <summary className="cursor-pointer text-lg font-medium text-slate-800 transition-colors group-open:text-emerald-600 dark:text-slate-200">
+              Will Google show the PriceHammer favicon next crawl?
+            </summary>
+            <p className="mt-2 text-slate-700 dark:text-slate-300">
+              Once Google recrawls the site it will pick up the updated metadata, descriptive URL, and manifest. You can request
+              indexing in Google Search Console to speed up the refresh.
+            </p>
+          </details>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated `/warhammer-prices` landing page with SEO-focused hero messaging, feature highlights, and FAQ content around the product lookup
- enhance global metadata with canonical URLs, Open Graph/Twitter cards, JSON-LD schema, and update navigation to promote the descriptive route
- refresh the manifest, robots.txt, sitemap, and supporting page copy to emphasize Australian Warhammer price comparisons

## Testing
- npm run lint *(fails: existing lint violations across admin/API files unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68df9b73b4c88330845ccad1b8d1172f