### PR TITLE
Add admin product editor and refresh product lookup experience

### DIFF
--- a/data/db/Product.ts
+++ b/data/db/Product.ts
@@ -5,7 +5,7 @@ export interface Product {
   game: string;
   faction: string;
   category: string;
-  points: number;
+  points: number | null;
   image: string;
   retailers: {
     store: string;

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -8,7 +8,7 @@
   ],
   "theme_color": "#0b1220",
   "background_color": "#0b1220",
-  "start_url": "/warhammer-prices",
+  "start_url": "/",
   "scope": "/",
   "display": "standalone"
 }

--- a/src/app/api/admin/products/[id]/route.ts
+++ b/src/app/api/admin/products/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+
+import { isAdminRequest } from "@/lib/auth";
+import { loadManualProduct, updateManualProduct } from "@/lib/manual-products";
+
+const ALLOWED_GAMES = new Set(["warhammer40k", "ageofsigmar", "universal"]);
+
+function error(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!isAdminRequest()) {
+    return error("Unauthorized", 403);
+  }
+
+  const id = params?.id;
+  if (!id) {
+    return error("Missing product id");
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return error("Invalid JSON body");
+  }
+
+  const name = typeof payload?.name === "string" ? payload.name.trim() : "";
+  if (!name) {
+    return error("Name is required");
+  }
+
+  const rawGame = typeof payload?.game === "string" ? payload.game : "";
+  if (!ALLOWED_GAMES.has(rawGame)) {
+    return error("Game must be one of warhammer40k, ageofsigmar, or universal");
+  }
+
+  const faction = typeof payload?.faction === "string" ? payload.faction.trim() : "";
+  const category = typeof payload?.category === "string" ? payload.category.trim() : "";
+
+  const rawPoints = payload?.points;
+  let points: number | null = null;
+  if (rawPoints !== null && rawPoints !== undefined && rawPoints !== "") {
+    const parsed = Number(rawPoints);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return error("Points must be a positive number");
+    }
+    points = Math.round(parsed);
+  }
+
+  const existing = await loadManualProduct(id);
+  if (!existing) {
+    return error(`Product ${id} not found`, 404);
+  }
+
+  const updated = await updateManualProduct(id, {
+    name,
+    game: rawGame,
+    faction,
+    category,
+    points,
+  });
+
+  revalidatePath(`/product/${id}`);
+  revalidatePath("/");
+  revalidatePath("/warhammer-prices");
+  revalidatePath("/api/lookup-data");
+
+  return NextResponse.json({ product: updated });
+}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -3,13 +3,15 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import { ThemeToggle } from "./ThemeToggle";
+
 /** Returns the tab CSS for active/inactive state */
 function tabClass(isActive: boolean) {
   return [
     "px-3 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap",
     isActive
-      ? "bg-slate-900 text-white"
-      : "text-slate-600 hover:text-slate-900 hover:bg-slate-100",
+      ? "bg-slate-900 text-white dark:bg-slate-200 dark:text-slate-900"
+      : "text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-slate-300 dark:hover:text-white dark:hover:bg-slate-800/70",
   ].join(" ");
 }
 
@@ -34,10 +36,10 @@ function NavItem({
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-40 border-b bg-white/90 backdrop-blur">
-      <div className="max-w-screen-xl mx-auto px-3 sm:px-6 lg:px-8 h-12 sm:h-14 flex items-center justify-between gap-2">
+    <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur dark:border-slate-800/80 dark:bg-slate-900/85">
+      <div className="max-w-screen-xl mx-auto px-3 sm:px-6 lg:px-8 h-12 sm:h-14 flex items-center justify-between gap-3">
         {/* Brand */}
-        <Link href="/warhammer-prices" className="inline-flex items-center gap-2 font-semibold text-slate-900">
+        <Link href="/" className="inline-flex items-center gap-2 font-semibold text-slate-900 dark:text-slate-100">
           {/* you can swap to next/image later if you want */}
           <img
             className="rounded-md"
@@ -50,24 +52,27 @@ export function Header() {
         </Link>
 
         {/* Nav (scrolls horizontally on mobile if needed) */}
-        <nav className="flex items-center gap-2 overflow-x-auto no-scrollbar -mx-2 px-2">
-          <NavItem href="/warhammer-prices" exact>
+        <div className="flex items-center gap-2">
+          <nav className="flex items-center gap-2 overflow-x-auto no-scrollbar -mx-2 px-2">
+            <NavItem href="/" exact>
             🔎 Product Lookup
           </NavItem>
 
-          <NavItem href="/about">About</NavItem>
-          <NavItem href="/contact">Contact</NavItem>
+            <NavItem href="/about">About</NavItem>
+            <NavItem href="/contact">Contact</NavItem>
 
-          {/* Region “button”—kept as non-route but styled like the tabs */}
-          <button
-            type="button"
-            className="px-3 py-2 rounded-md text-sm font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-100 whitespace-nowrap"
-            aria-label="Change region"
-            title="Change region (WIP)"
-          >
-            Change Region: <span className="ml-1 align-middle">🇦🇺 (WIP)</span>
-          </button>
-        </nav>
+            {/* Region “button”—kept as non-route but styled like the tabs */}
+            <button
+              type="button"
+              className="px-3 py-2 rounded-md text-sm font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-100 whitespace-nowrap dark:text-slate-300 dark:hover:text-white dark:hover:bg-slate-800/70"
+              aria-label="Change region"
+              title="Change region (WIP)"
+            >
+              Change Region: <span className="ml-1 align-middle">🇦🇺 (WIP)</span>
+            </button>
+          </nav>
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   );

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -1,26 +1,58 @@
+"use client";
+
 import { useEffect, useState } from "react";
 import { Moon, Sun } from "lucide-react";
+
 import { Button } from "@/components/ui/button";
 
+type Theme = "light" | "dark";
+const STORAGE_KEY = "theme";
+
 export function ThemeToggle() {
-  const [dark, setDark] = useState(() =>
-    document.documentElement.classList.contains("dark")
-  );
+  const [theme, setTheme] = useState<Theme>("light");
+  const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
-    if (dark) {
-      document.documentElement.classList.add("dark");
-      localStorage.setItem("theme", "dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-      localStorage.setItem("theme", "light");
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const initial = stored ?? (prefersDark ? "dark" : "light");
+      setTheme(initial);
+      document.documentElement.classList.toggle("dark", initial === "dark");
+    } catch {
+      // ignore errors (e.g. storage disabled)
+    } finally {
+      setHydrated(true);
     }
-  }, [dark]);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // ignore
+    }
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  }, [theme, hydrated]);
+
+  const toggle = () => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  };
+
+  const isDark = theme === "dark";
 
   return (
-    <Button variant="outline" size="sm" onClick={() => setDark(d => !d)}>
-      {dark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-      <span className="ml-2 hidden sm:inline">{dark ? "Light" : "Dark"}</span>
+    <Button
+      variant="outline"
+      size="sm"
+      type="button"
+      onClick={toggle}
+      aria-pressed={isDark}
+      className="gap-2"
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      <span className="hidden sm:inline">{isDark ? "Light mode" : "Dark mode"}</span>
     </Button>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,6 +39,7 @@ export const metadata: Metadata = {
   publisher: "PriceHammer",
   icons: {
     icon: [
+      { url: "/favicon.svg", type: "image/svg+xml" },
       { url: "/favicon.ico" },
       { url: "/favicon-32x32.png", type: "image/png", sizes: "32x32" },
       { url: "/favicon-16x16.png", type: "image/png", sizes: "16x16" },
@@ -50,11 +51,11 @@ export const metadata: Metadata = {
   },
   manifest: "/site.webmanifest",
   alternates: {
-    canonical: "/warhammer-prices",
+    canonical: "/",
   },
   openGraph: {
     type: "website",
-    url: "/warhammer-prices",
+    url: "/",
     title: "Warhammer Price Tracker for Australia | PriceHammer",
     description: primaryDescription,
     siteName: "PriceHammer",
@@ -91,19 +92,35 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={`${sans.variable} ${display.variable}`}>
       <head>
+        <Script id="theme-init" strategy="beforeInteractive">
+          {`
+            try {
+              const stored = localStorage.getItem('theme');
+              if (stored === 'dark') {
+                document.documentElement.classList.add('dark');
+              } else if (stored === 'light') {
+                document.documentElement.classList.remove('dark');
+              } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                document.documentElement.classList.add('dark');
+              }
+            } catch (e) {
+              // ignore
+            }
+          `}
+        </Script>
         <Script id="ld-json-website" type="application/ld+json" strategy="beforeInteractive">
           {JSON.stringify({
             "@context": "https://schema.org",
             "@type": "WebSite",
             name: "PriceHammer",
-            url: `${metadataBase.origin}/warhammer-prices`,
+            url: `${metadataBase.origin}/`,
             description: primaryDescription,
             inLanguage: "en-AU",
             potentialAction: {
               "@type": "SearchAction",
               target: {
                 "@type": "EntryPoint",
-                urlTemplate: `${metadataBase.origin}/warhammer-prices?search={search_term_string}`,
+                urlTemplate: `${metadataBase.origin}/?search={search_term_string}`,
               },
               "query-input": "required name=search_term_string",
             },

--- a/src/app/lib/auth.ts
+++ b/src/app/lib/auth.ts
@@ -1,0 +1,25 @@
+import { Buffer } from "node:buffer";
+import { headers } from "next/headers";
+
+export function isAdminRequest(): boolean {
+  const USER = process.env.ADMIN_USER;
+  const PASS = process.env.ADMIN_PASS;
+
+  if (!USER || !PASS) {
+    // When credentials aren't configured (e.g. local dev), treat everyone as admin
+    return true;
+  }
+
+  try {
+    const headerList = headers();
+    const auth = headerList.get("authorization");
+    if (!auth || !auth.startsWith("Basic ")) {
+      return false;
+    }
+    const decoded = Buffer.from(auth.slice(6), "base64").toString("utf8");
+    const [user, pass] = decoded.split(":");
+    return user === USER && pass === PASS;
+  } catch {
+    return false;
+  }
+}

--- a/src/app/lib/manual-products.ts
+++ b/src/app/lib/manual-products.ts
@@ -1,0 +1,125 @@
+import fs from "fs/promises";
+import path from "path";
+
+export type ManualProduct = {
+  id: string;
+  name: string;
+  game?: "warhammer40k" | "ageofsigmar" | "universal" | string;
+  faction?: string;
+  category?: string;
+  points?: number | null;
+  image?: string;
+  description?: string;
+  retailers?: {
+    store: string;
+    price: number;
+    inStock: boolean;
+    url: string | null;
+  }[];
+};
+
+const PRODUCTS_FILE = path.join(process.cwd(), "data/db/Product.ts");
+const PRODUCTS_EXPORT = "export const Products";
+
+function findProductsBounds(source: string) {
+  const exportIdx = source.indexOf(PRODUCTS_EXPORT);
+  if (exportIdx === -1) {
+    throw new Error("Products export not found in Product.ts");
+  }
+  const arrayStart = source.indexOf("[", exportIdx);
+  if (arrayStart === -1) {
+    throw new Error("Products array start not found");
+  }
+  let depth = 0;
+  let i = arrayStart;
+  for (; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "[") depth++;
+    else if (ch === "]") {
+      depth--;
+      if (depth === 0) {
+        break;
+      }
+    }
+  }
+  if (depth !== 0) {
+    throw new Error("Unbalanced brackets in Product.ts");
+  }
+  const arrayEnd = i + 1; // include closing bracket
+  return { arrayStart, arrayEnd };
+}
+
+function parseProducts(source: string): ManualProduct[] {
+  const { arrayStart, arrayEnd } = findProductsBounds(source);
+  const arraySource = source.slice(arrayStart, arrayEnd);
+  return JSON.parse(arraySource) as ManualProduct[];
+}
+
+function formatProducts(products: ManualProduct[]): string {
+  if (products.length === 0) {
+    return "[]";
+  }
+  const items = products
+    .map((product) => JSON.stringify(product, null, 2))
+    .map((block) => block.split("\n").map((line) => `  ${line}`).join("\n"))
+    .join(",\n");
+  return `[\n${items}\n]`;
+}
+
+export async function loadManualProducts(): Promise<ManualProduct[]> {
+  const raw = await fs.readFile(PRODUCTS_FILE, "utf8");
+  return parseProducts(raw);
+}
+
+export async function loadManualProduct(id: string): Promise<ManualProduct | undefined> {
+  const products = await loadManualProducts();
+  return products.find((p) => String(p.id) === String(id));
+}
+
+export async function saveManualProducts(products: ManualProduct[]): Promise<void> {
+  const raw = await fs.readFile(PRODUCTS_FILE, "utf8");
+  const { arrayStart, arrayEnd } = findProductsBounds(raw);
+  const formatted = formatProducts(products);
+  const updated = `${raw.slice(0, arrayStart)}${formatted}${raw.slice(arrayEnd)}`;
+  await fs.writeFile(PRODUCTS_FILE, updated, "utf8");
+}
+
+export async function updateManualProduct(
+  id: string,
+  updates: Partial<Pick<ManualProduct, "name" | "game" | "faction" | "category" | "points">>,
+): Promise<ManualProduct> {
+  const raw = await fs.readFile(PRODUCTS_FILE, "utf8");
+  const products = parseProducts(raw);
+  const index = products.findIndex((p) => String(p.id) === String(id));
+  if (index === -1) {
+    throw new Error(`Product ${id} not found`);
+  }
+
+  const existing = products[index];
+  const next: ManualProduct = { ...existing };
+
+  if (updates.name !== undefined) {
+    next.name = updates.name;
+  }
+  if (updates.game !== undefined) {
+    next.game = updates.game;
+  }
+  if (updates.faction !== undefined) {
+    next.faction = updates.faction;
+  }
+  if (updates.category !== undefined) {
+    next.category = updates.category;
+  }
+  if (updates.points !== undefined) {
+    next.points = updates.points;
+  }
+
+  products[index] = next;
+
+  const { arrayStart, arrayEnd } = findProductsBounds(raw);
+  const formatted = formatProducts(products);
+  const updated = `${raw.slice(0, arrayStart)}${formatted}${raw.slice(arrayEnd)}`;
+  await fs.writeFile(PRODUCTS_FILE, updated, "utf8");
+
+  return next;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,84 @@
-// src/app/page.tsx
-import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+
+import { ProductLookup } from "@/components/ProductLookup";
+
+const pageDescription =
+  "Compare Games Workshop prices from hobby stores with PriceHammer so you can spot stock and savings before checking out.";
+
+export const metadata: Metadata = {
+  title: "Warhammer Price Comparison Tool",
+  description: pageDescription,
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    title: "Warhammer Price Comparison Tool | PriceHammer",
+    description: pageDescription,
+    url: "/",
+  },
+  twitter: {
+    title: "Warhammer Price Comparison Tool | PriceHammer",
+    description: pageDescription,
+  },
+};
 
 export default function HomePage() {
-  redirect("/warhammer-prices");
+  return (
+    <div className="space-y-12">
+      <section className="space-y-6 text-center sm:text-left">
+        <p className="inline-flex items-center gap-2 rounded-full bg-amber-100 px-4 py-1 text-sm font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-200">
+          This Warhammer price tracker is currently only available for Australian 🇦🇺 Retailers!
+        </p>
+        <h1 className="text-4xl font-display font-bold text-slate-900 dark:text-white">
+          Find the best Warhammer deals in Australia!
+        </h1>
+
+        <p className="mx-auto max-w-3xl text-lg text-slate-700 dark:text-slate-300 flex items-start gap-2 rounded-lg border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/50">
+          This website monitors Games Workshop products from third party retailers so you can compare prices, check stock,
+          and jump on deals before they sell out. More regions will follow once local data is ready.
+        </p>
+      </section>
+
+      <section aria-labelledby="lookup-heading" className="space-y-4">
+        <h2 id="lookup-heading" className="sr-only">
+          Warhammer price lookup
+        </h2>
+        <ProductLookup />
+      </section>
+
+      <section aria-labelledby="faq-heading" className="space-y-4">
+        <h2 id="faq-heading" className="text-2xl font-display font-semibold text-slate-900 dark:text-white">
+          Frequently asked questions
+        </h2>
+        <div className="space-y-3">
+          <details className="group rounded-lg border border-slate-200 bg-white/80 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <summary className="cursor-pointer text-lg font-medium text-slate-800 transition-colors group-open:text-emerald-600 dark:text-slate-200">
+              Where do the prices come from?
+            </summary>
+            <p className="mt-2 text-slate-700 dark:text-slate-300">
+              We track publicly listed prices from Australian hobby stores and refresh the listings regularly. Each product links
+              directly to the retailer.
+            </p>
+          </details>
+          <details className="group rounded-lg border border-slate-200 bg-white/80 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <summary className="cursor-pointer text-lg font-medium text-slate-800 transition-colors group-open:text-emerald-600 dark:text-slate-200">
+              How can I request a store or product to be added?
+            </summary>
+            <p className="mt-2 text-slate-700 dark:text-slate-300">
+              Email me to suggest new retailers or Games Workshop releases. Community feedback helps prioritise the next data
+              imports and ensures regional coverage stays accurate.
+            </p>
+          </details>
+          <details className="group rounded-lg border border-slate-200 bg-white/80 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+            <summary className="cursor-pointer text-lg font-medium text-slate-800 transition-colors group-open:text-emerald-600 dark:text-slate-200">
+              I found a broken link/item, what can I do?
+            </summary>
+            <p className="mt-2 text-slate-700 dark:text-slate-300">
+              Email me, or hit the report button! Every report helps!
+            </p>
+          </details>
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/src/app/product/[id]/ProductEditor.tsx
+++ b/src/app/product/[id]/ProductEditor.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const GAME_OPTIONS: { value: "warhammer40k" | "ageofsigmar" | "universal"; label: string }[] = [
+  { value: "warhammer40k", label: "Warhammer 40,000 (40K)" },
+  { value: "ageofsigmar", label: "Age of Sigmar" },
+  { value: "universal", label: "Universal" },
+];
+
+interface ProductEditorProps {
+  productId: string;
+  initialData: {
+    name: string;
+    game: "warhammer40k" | "ageofsigmar" | "universal";
+    faction: string;
+    category: string;
+    points: number | null;
+  };
+}
+
+export function ProductEditor({ productId, initialData }: ProductEditorProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(initialData.name);
+  type GameValue = (typeof GAME_OPTIONS)[number]["value"];
+  const [game, setGame] = useState<GameValue>(initialData.game);
+  const [faction, setFaction] = useState(initialData.faction);
+  const [category, setCategory] = useState(initialData.category);
+  const [points, setPoints] = useState(initialData.points?.toString() ?? "");
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setName(initialData.name);
+    setGame(initialData.game);
+    setFaction(initialData.faction);
+    setCategory(initialData.category);
+    setPoints(initialData.points?.toString() ?? "");
+  }, [initialData.name, initialData.game, initialData.faction, initialData.category, initialData.points]);
+
+  const toggle = () => {
+    setOpen((prev) => !prev);
+    setMessage(null);
+    setError(null);
+  };
+
+  const reset = () => {
+    setName(initialData.name);
+    setGame(initialData.game);
+    setFaction(initialData.faction);
+    setCategory(initialData.category);
+    setPoints(initialData.points?.toString() ?? "");
+    setMessage(null);
+    setError(null);
+  };
+
+  const submit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSaving(true);
+    setMessage(null);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/admin/products/${productId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          game,
+          faction,
+          category,
+          points: points.trim() === "" ? null : Number(points),
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data?.error ?? "Failed to save changes");
+      }
+
+      setMessage("Saved");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save changes");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Button variant="outline" size="sm" onClick={toggle} type="button">
+        {open ? "Close editor" : "Edit"}
+      </Button>
+
+      {open && (
+        <form
+          onSubmit={submit}
+          className="absolute right-0 mt-2 w-[320px] space-y-3 rounded-md border border-slate-200 bg-white p-4 text-left shadow-lg dark:border-slate-700 dark:bg-slate-900 z-20"
+        >
+          <div className="space-y-1">
+            <label
+              htmlFor="product-name"
+              className="text-sm font-medium text-slate-700 dark:text-slate-200"
+            >
+              Name
+            </label>
+            <Input
+              id="product-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              required
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label
+              htmlFor="product-game"
+              className="text-sm font-medium text-slate-700 dark:text-slate-200"
+            >
+              Game
+            </label>
+            <Select value={game} onValueChange={(value) => setGame(value as GameValue)}>
+              <SelectTrigger id="product-game">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {GAME_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1">
+            <label
+              htmlFor="product-faction"
+              className="text-sm font-medium text-slate-700 dark:text-slate-200"
+            >
+              Faction
+            </label>
+            <Input
+              id="product-faction"
+              value={faction}
+              onChange={(event) => setFaction(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label
+              htmlFor="product-category"
+              className="text-sm font-medium text-slate-700 dark:text-slate-200"
+            >
+              Category
+            </label>
+            <Input
+              id="product-category"
+              value={category}
+              onChange={(event) => setCategory(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label
+              htmlFor="product-points"
+              className="text-sm font-medium text-slate-700 dark:text-slate-200"
+            >
+              Points
+            </label>
+            <Input
+              id="product-points"
+              type="number"
+              value={points}
+              onChange={(event) => setPoints(event.target.value)}
+              min={0}
+            />
+          </div>
+
+          {message && <p className="text-sm text-emerald-600">{message}</p>}
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <div className="flex items-center justify-between gap-2 pt-2">
+            <Button type="button" variant="ghost" size="sm" onClick={reset} disabled={saving}>
+              Reset
+            </Button>
+            <Button type="submit" size="sm" disabled={saving}>
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/app/warhammer-prices/page.tsx
+++ b/src/app/warhammer-prices/page.tsx
@@ -1,83 +1,15 @@
 import type { Metadata } from "next";
-import { ProductLookup } from "@/components/ProductLookup";
-
-const pageDescription =
-  "Compare Games Workshop prices from hobby stores with PriceHammer so you can spot stock and savings before checking out.";
+import { redirect } from "next/navigation";
 
 export const metadata: Metadata = {
   title: "Warhammer Price Comparison Tool",
-  description: pageDescription,
+  description:
+    "Compare Games Workshop prices from hobby stores with PriceHammer so you can spot stock and savings before checking out.",
   alternates: {
-    canonical: "/warhammer-prices",
-  },
-  openGraph: {
-    title: "Warhammer Price Comparison Tool | PriceHammer",
-    description: pageDescription,
-    url: "/warhammer-prices",
-  },
-  twitter: {
-    title: "Warhammer Price Comparison Tool | PriceHammer",
-    description: pageDescription,
+    canonical: "/",
   },
 };
 
-export default function WarhammerPricesPage() {
-  return (
-    <div className="space-y-12">
-      <section className="space-y-6 text-center sm:text-left">
-        <p className="inline-flex items-center gap-2 rounded-full bg-amber-100 px-4 py-1 text-sm font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-200">
-          This Warhammer price tracker is currently only available for Australian 🇦🇺 Retailers! 
-        </p>
-        <h1 className="text-4xl font-display font-bold text-slate-900 dark:text-white">
-          Find the best Warhammer deals in Australia!
-        </h1>
-        
-        <p className="mx-auto max-w-3xl text-lg text-slate-700 dark:text-slate-300 flex items-start gap-2 rounded-lg border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/50">
-          This website monitors Games Workshop products from third party retailers so you can compare prices, check stock,
-          and jump on deals before they sell out. More regions will follow once local data is ready.
-        </p>
-      </section>
-
-      <section aria-labelledby="lookup-heading" className="space-y-4">
-        <h2 id="lookup-heading" className="sr-only">
-          Warhammer price lookup
-        </h2>
-        <ProductLookup />
-      </section>
-
-      <section aria-labelledby="faq-heading" className="space-y-4">
-        <h2 id="faq-heading" className="text-2xl font-display font-semibold text-slate-900 dark:text-white">
-          Frequently asked questions
-        </h2>
-        <div className="space-y-3">
-          <details className="group rounded-lg border border-slate-200 bg-white/80 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
-            <summary className="cursor-pointer text-lg font-medium text-slate-800 transition-colors group-open:text-emerald-600 dark:text-slate-200">
-              Where do the prices come from?
-            </summary>
-            <p className="mt-2 text-slate-700 dark:text-slate-300">
-              We track publicly listed prices from Australian hobby stores and refresh the listings regularly. Each product
-              links directly to the retailer.
-            </p>
-          </details>
-          <details className="group rounded-lg border border-slate-200 bg-white/80 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
-            <summary className="cursor-pointer text-lg font-medium text-slate-800 transition-colors group-open:text-emerald-600 dark:text-slate-200">
-              How can I request a store or product to be added?
-            </summary>
-            <p className="mt-2 text-slate-700 dark:text-slate-300">
-              Email me to suggest new retailers or Games Workshop releases. Community feedback helps prioritise the
-              next data imports and ensures regional coverage stays accurate.
-            </p>
-          </details>
-          <details className="group rounded-lg border border-slate-200 bg-white/80 p-4 text-left shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
-            <summary className="cursor-pointer text-lg font-medium text-slate-800 transition-colors group-open:text-emerald-600 dark:text-slate-200">
-              I found a broken link/item, what can I do?
-            </summary>
-            <p className="mt-2 text-slate-700 dark:text-slate-300">
-              Email me, or hit the report button! Every report helps!
-            </p>
-          </details>
-        </div>
-      </section>
-    </div>
-  );
+export default function LegacyWarhammerPricesPage() {
+  redirect("/");
 }


### PR DESCRIPTION
## Summary
- add an admin-only editor on product detail pages that persists manual metadata updates back to the shared Product dataset
- expose a secured API endpoint and shared helpers for loading/updating manual product metadata and refresh product lookup results with the new game filtering options
- update the public site shell with a persistent dark-mode toggle, move the lookup experience to the home route, and align metadata/favicons with the root URL
