### PR TITLE
Persist manual product overrides in SQLite

### DIFF
--- a/data/db/Product.ts
+++ b/data/db/Product.ts
@@ -2,10 +2,11 @@
 export interface Product {
   id: string;
   name: string;
-  game: string;
-  faction: string;
-  category: string;
-  points: number;
+  game?: string | null;
+  faction?: string | null;
+  category?: string | null;
+  points?: number | null;
+  hidden?: boolean;
   image: string;
   retailers: {
     store: string;

--- a/data/db/queries/create/manual_product_overrides.sql
+++ b/data/db/queries/create/manual_product_overrides.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS manual_product_overrides (
+  product_id INTEGER PRIMARY KEY REFERENCES products(id) ON DELETE CASCADE,
+  name TEXT,
+  game TEXT,
+  faction TEXT,
+  category TEXT,
+  points INTEGER,
+  hidden INTEGER,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/data/db/queries/select/manual_product_override.sql
+++ b/data/db/queries/select/manual_product_override.sql
@@ -1,0 +1,9 @@
+SELECT product_id,
+       name,
+       game,
+       faction,
+       category,
+       points,
+       hidden
+  FROM manual_product_overrides
+ WHERE product_id = ?;

--- a/data/db/queries/select/manual_product_overrides.sql
+++ b/data/db/queries/select/manual_product_overrides.sql
@@ -1,0 +1,8 @@
+SELECT product_id,
+       name,
+       game,
+       faction,
+       category,
+       points,
+       hidden
+  FROM manual_product_overrides;

--- a/data/db/queries/select/manual_product_overrides_count.sql
+++ b/data/db/queries/select/manual_product_overrides_count.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) AS count
+  FROM manual_product_overrides;

--- a/data/db/queries/update/upsert_manual_product_override.sql
+++ b/data/db/queries/update/upsert_manual_product_override.sql
@@ -1,0 +1,18 @@
+INSERT INTO manual_product_overrides (
+  product_id,
+  name,
+  game,
+  faction,
+  category,
+  points,
+  hidden,
+  updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+ON CONFLICT(product_id) DO UPDATE SET
+  name = excluded.name,
+  game = excluded.game,
+  faction = excluded.faction,
+  category = excluded.category,
+  points = excluded.points,
+  hidden = excluded.hidden,
+  updated_at = datetime('now');

--- a/src/app/admin/setup/route.ts
+++ b/src/app/admin/setup/route.ts
@@ -26,6 +26,7 @@ export async function POST() {
     await query("run", "create/products");
     await query("run", "create/prices");
     await query("run", "create/sellers");
+    await query("run", "create/manual_product_overrides");
     try { await query("run", "create/bug_reports"); } catch {}
 
     // 2) Load JSON seed files

--- a/src/app/api/admin/products/[id]/metadata/route.ts
+++ b/src/app/api/admin/products/[id]/metadata/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isAuthorizedAdmin } from "@/app/lib/auth";
+import {
+  ManualProductRecord,
+  loadManualProductById,
+  saveManualProductOverride,
+} from "@/app/lib/manual-products";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Params = { params: Promise<{ id: string }> };
+
+type Body = {
+  name?: string | null;
+  game?: string | null;
+  faction?: string | null;
+  category?: string | null;
+  points?: number | string | null;
+  hidden?: boolean | null;
+};
+
+function applyNameField(target: ManualProductRecord, body: Body) {
+  if (!Object.prototype.hasOwnProperty.call(body, "name")) return;
+  const raw = body.name;
+
+  if (raw === null || raw === undefined) {
+    throw new Error("invalid-name");
+  }
+
+  if (typeof raw !== "string") {
+    throw new Error("invalid-name");
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("invalid-name");
+  }
+
+  target.name = trimmed;
+}
+
+function applyStringField(
+  target: ManualProductRecord,
+  body: Body,
+  key: "game" | "faction" | "category",
+) {
+  if (!Object.prototype.hasOwnProperty.call(body, key)) return;
+  const raw = body[key];
+
+  if (raw === null || raw === undefined) {
+    delete target[key];
+    return;
+  }
+
+  if (typeof raw !== "string") {
+    throw new Error(`invalid-${key}`);
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    delete target[key];
+    return;
+  }
+
+  target[key] = trimmed;
+}
+
+function applyPointsField(target: ManualProductRecord, body: Body) {
+  if (!Object.prototype.hasOwnProperty.call(body, "points")) return;
+  const raw = body.points;
+
+  if (raw === null || raw === undefined || raw === "") {
+    delete target.points;
+    return;
+  }
+
+  const value = typeof raw === "number" ? raw : Number(String(raw).trim());
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error("invalid-points");
+  }
+
+  target.points = value;
+}
+
+function applyHiddenField(target: ManualProductRecord, body: Body) {
+  if (!Object.prototype.hasOwnProperty.call(body, "hidden")) return;
+  const raw = body.hidden;
+
+  if (raw === null || raw === undefined) {
+    delete target.hidden;
+    return;
+  }
+
+  if (typeof raw !== "boolean") {
+    throw new Error("invalid-hidden");
+  }
+
+  target.hidden = raw;
+}
+
+function buildUpdatedProduct(existing: ManualProductRecord, body: Body) {
+  const updated: ManualProductRecord = { ...existing };
+
+  applyNameField(updated, body);
+  applyStringField(updated, body, "game");
+  applyStringField(updated, body, "faction");
+  applyStringField(updated, body, "category");
+  applyPointsField(updated, body);
+  applyHiddenField(updated, body);
+
+  return updated;
+}
+
+export async function PUT(req: NextRequest, { params }: Params) {
+  const authHeader = req.headers.get("authorization");
+  if (!isAuthorizedAdmin(authHeader)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const existing = await loadManualProductById(id);
+  if (!existing) {
+    return NextResponse.json({ error: "Product not found" }, { status: 404 });
+  }
+
+  let updatedProduct: ManualProductRecord;
+  try {
+    updatedProduct = buildUpdatedProduct(existing, body);
+  } catch (error: unknown) {
+    const code = error instanceof Error && typeof error.message === "string" ? error.message : "invalid-input";
+    const message =
+      code === "invalid-points"
+        ? "Points must be a non-negative number"
+        : code === "invalid-name"
+        ? "Name must be provided"
+        : code === "invalid-hidden"
+        ? "Hidden must be true or false"
+        : "Invalid input received";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  try {
+    const stored = await saveManualProductOverride(id, updatedProduct);
+    return NextResponse.json({ ok: true, product: stored ?? updatedProduct });
+  } catch (error) {
+    const code = error instanceof Error && error.message ? error.message : "persist-failed";
+    if (code === "invalid-name") {
+      return NextResponse.json({ error: "Name must be provided" }, { status: 400 });
+    }
+    console.error("[product-metadata] Failed to persist override", error);
+    return NextResponse.json({ error: "Failed to persist changes" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/products/manual/download/route.ts
+++ b/src/app/api/admin/products/manual/download/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+import { isAuthorizedAdmin } from "@/app/lib/auth";
+import { readManualProductsFile } from "@/app/lib/manual-products";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const authHeader = req.headers.get("authorization");
+  if (!isAuthorizedAdmin(authHeader)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { filePath } = await readManualProductsFile();
+    const contents = await fs.readFile(filePath, "utf8");
+    const filename = path.basename(filePath);
+
+    return new NextResponse(contents, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/typescript; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    console.error("[product-metadata] Failed to read Product.ts", error);
+    return NextResponse.json({ error: "Unable to download Product.ts" }, { status: 500 });
+  }
+}

--- a/src/app/components/ProductLookup.tsx
+++ b/src/app/components/ProductLookup.tsx
@@ -34,6 +34,7 @@ type Product = {
   category?: string;
   points?: number;
   image?: string | null;
+  hidden?: boolean;
   retailers: Retailer[];
 };
 
@@ -194,7 +195,7 @@ const sample = <T,>(arr: T[], n: number) => {
 export function ProductLookup() {
   // Start with manual products (no retailers) so UI renders immediately.
   const [sourceProducts, setSourceProducts] = useState<Product[]>(
-    () => ManualProducts.map((p) => ({ ...p, retailers: [] }))
+    () => ManualProducts.filter((p) => p.hidden !== true).map((p) => ({ ...p, retailers: [] }))
   );
   const [queryInput, setQueryInput] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
@@ -213,7 +214,8 @@ export function ProductLookup() {
         if (!res.ok) throw new Error(await res.text());
         const data: { products: Product[] } = await res.json();
         if (!cancelled && Array.isArray(data?.products)) {
-          setSourceProducts(data.products);
+          const visible = data.products.filter((product) => product.hidden !== true);
+          setSourceProducts(visible);
         }
       } catch (e) {
         console.warn("Falling back to manual products only (no DB retailers).", e);
@@ -342,13 +344,13 @@ export function ProductLookup() {
           </button>
         </form>
 
-        {/* game */}
+        {/* universe */}
         <Select value={selectedGame} onValueChange={setSelectedGame}>
           <SelectTrigger className="w-[180px] bg-white dark:bg-slate-800 ">
-            <SelectValue placeholder="All Games" />
+            <SelectValue placeholder="All Universes" />
           </SelectTrigger>
           <SelectContent className="w-[180px] bg-white dark:bg-slate-800">
-            <SelectItem value="all">All Games</SelectItem>
+            <SelectItem value="all">All Universes</SelectItem>
             {(["warhammer40k", "ageofsigmar"] as const).map((g) => (
               <SelectItem key={g} value={g}>{g}</SelectItem>
             ))}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,4 @@
-/* Fonts (safe to keep here; swap to self-hosted if you prefer) */
-@import url("https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Merriweather:wght@300;400;700&family=Montserrat:wght@600;700&display=swap");
 @import "tailwindcss";
-/* Fonts (safe to keep here; swap to self-hosted if you prefer) */
 
 @custom-variant dark (&:is(.dark *));
 
@@ -11,11 +8,6 @@
 /* ---- Design tokens ---- */
 @theme {
   --radius: 0.625rem; /* slightly larger default */
-
-  /* Font vars (global) */
-  --font-display: "Bebas Neue";
-  --font-serif: "Merriweather";
-  --font-ui: "Montserrat";
 
   /* Brand accent (Warhammer button yellow) */
   --brand-yellow: oklch(0.89 0.19 98);
@@ -168,24 +160,52 @@
   /* Serif body for that GW vibe; keep UI sans for controls */
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+    font-family: var(--font-serif), "Merriweather", Georgia, "Times New Roman", serif;
     font-feature-settings: "liga","kern";
     text-rendering: optimizeLegibility;
+    letter-spacing: 0.005em;
+    line-height: 1.65;
+    font-size: clamp(1rem, 0.97rem + 0.25vw, 1.12rem);
   }
 
   /* Headings use display font */
   h1, h2, h3, .display {
-    font-family: var(--font-display), Impact, system-ui, sans-serif;
-    letter-spacing: 0.02em;
-    line-height: 0.95;
+    font-family: var(--font-display), "Bebas Neue", Impact, system-ui, sans-serif;
+    letter-spacing: 0.08em;
+    line-height: 0.9;
     text-transform: uppercase;
+    text-rendering: optimizeLegibility;
+    text-shadow: 0 2px 6px color-mix(in oklch, black 25%, transparent);
+  }
+
+  h4, h5, h6 {
+    font-family: var(--font-ui), "Montserrat", system-ui, sans-serif;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  p, li {
+    max-width: 70ch;
+  }
+
+  strong {
+    font-weight: 700;
   }
 }
 
 /* ---- Utilities ---- */
 @layer utilities {
-  .font-display { font-family: var(--font-display), Impact, system-ui, sans-serif !important; }
-  .font-ui { font-family: var(--font-ui), system-ui, sans-serif !important; }
+  .font-display {
+    font-family: var(--font-display), "Bebas Neue", Impact, system-ui, sans-serif !important;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .font-ui {
+    font-family: var(--font-ui), "Montserrat", system-ui, sans-serif !important;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
 
   /* CTA pill like the screenshot */
   .btn-primary {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,15 +4,24 @@ import Script from "next/script";
 import "./globals.css";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
-import { EB_Garamond, Inter } from "next/font/google";
+import { Bebas_Neue, Merriweather, Montserrat } from "next/font/google";
 
-const display = EB_Garamond({
+const display = Bebas_Neue({
   subsets: ["latin"],
+  weight: "400",
   variable: "--font-display",
 });
-const sans = Inter({
+
+const serif = Merriweather({
   subsets: ["latin"],
-  variable: "--font-sans",
+  weight: ["300", "400", "700"],
+  variable: "--font-serif",
+});
+
+const ui = Montserrat({
+  subsets: ["latin"],
+  weight: ["500", "600", "700"],
+  variable: "--font-ui",
 });
 
 const metadataBase = new URL("https://pricehammer.xyz");
@@ -89,7 +98,7 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${sans.variable} ${display.variable}`}>
+    <html lang="en" className={`${display.variable} ${serif.variable} ${ui.variable}`}>
       <head>
         <Script id="ld-json-website" type="application/ld+json" strategy="beforeInteractive">
           {JSON.stringify({

--- a/src/app/lib/auth.ts
+++ b/src/app/lib/auth.ts
@@ -1,0 +1,32 @@
+const BASIC_PREFIX = "Basic ";
+
+function decodeBasicAuth(auth: string) {
+  try {
+    const base64 = auth.slice(BASIC_PREFIX.length);
+    const decoded = Buffer.from(base64, "base64").toString("utf8");
+    const separatorIndex = decoded.indexOf(":");
+    if (separatorIndex === -1) return { user: "", pass: "" };
+    const user = decoded.slice(0, separatorIndex);
+    const pass = decoded.slice(separatorIndex + 1);
+    return { user, pass };
+  } catch {
+    return { user: "", pass: "" };
+  }
+}
+
+export function isAuthorizedAdmin(authHeader?: string | null): boolean {
+  const expectedUser = process.env.ADMIN_USER;
+  const expectedPass = process.env.ADMIN_PASS;
+
+  if (!expectedUser || !expectedPass) {
+    // When credentials are not configured (e.g. local dev) treat everyone as admin.
+    return true;
+  }
+
+  if (!authHeader || !authHeader.startsWith(BASIC_PREFIX)) {
+    return false;
+  }
+
+  const { user, pass } = decodeBasicAuth(authHeader);
+  return user === expectedUser && pass === expectedPass;
+}

--- a/src/app/lib/manual-products.ts
+++ b/src/app/lib/manual-products.ts
@@ -1,0 +1,400 @@
+import path from "path";
+import fs from "fs/promises";
+
+import { query } from "./sql";
+
+export type ManualProductRecord = Record<string, unknown>;
+
+type ManualProductOverrideRow = {
+  product_id: number;
+  name: string | null;
+  game: string | null;
+  faction: string | null;
+  category: string | null;
+  points: number | null;
+  hidden: number | null;
+};
+
+type ManualProductOverride = {
+  id: string;
+  name?: string;
+  game?: string | null;
+  faction?: string | null;
+  category?: string | null;
+  points?: number | null;
+  hidden?: boolean | null;
+};
+
+export type ManualProductsFile = {
+  filePath: string;
+  before: string;
+  after: string;
+  products: ManualProductRecord[];
+  gameCategories: Record<string, string[]>;
+};
+
+const PRODUCTS_MARKER = "export const Products: Product[] =";
+const GAME_CATEGORIES_MARKER = "export const gameCategories =";
+
+function extractProducts(source: string) {
+  const markerIndex = source.indexOf(PRODUCTS_MARKER);
+  if (markerIndex === -1) {
+    throw new Error("Unable to locate Products array in Product.ts");
+  }
+
+  const arrayStart = source.indexOf("[", markerIndex + PRODUCTS_MARKER.length);
+  const arrayEnd = source.indexOf("];", arrayStart);
+  if (arrayStart === -1 || arrayEnd === -1) {
+    throw new Error("Unable to parse Products array");
+  }
+
+  const before = source.slice(0, arrayStart);
+  const after = source.slice(arrayEnd + 2);
+  const arrayContent = source.slice(arrayStart, arrayEnd + 1);
+  const parsed = JSON.parse(arrayContent) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error("Manual products data is not an array");
+  }
+
+  return {
+    before,
+    after,
+    products: parsed as ManualProductRecord[],
+  };
+}
+
+function stripComments(input: string) {
+  return input.replace(/\/\/[^\n]*|\/\*[\s\S]*?\*\//g, "");
+}
+
+function extractGameCategories(source: string) {
+  const markerIndex = source.indexOf(GAME_CATEGORIES_MARKER);
+  if (markerIndex === -1) {
+    return {};
+  }
+
+  const braceStart = source.indexOf("{", markerIndex + GAME_CATEGORIES_MARKER.length);
+  if (braceStart === -1) {
+    return {};
+  }
+
+  let depth = 0;
+  let endIndex = -1;
+  for (let i = braceStart; i < source.length; i += 1) {
+    const char = source[i];
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        endIndex = i;
+        break;
+      }
+    }
+  }
+
+  if (endIndex === -1) {
+    return {};
+  }
+
+  const rawObject = source.slice(braceStart, endIndex + 1);
+  const withoutComments = stripComments(rawObject);
+  const normalizedKeys = withoutComments.replace(/(\s*)([A-Za-z0-9_]+)\s*:/g, (match, whitespace, key) => {
+    return `${whitespace}"${key}":`;
+  });
+  const normalizedQuotes = normalizedKeys.replace(/'/g, '"');
+
+  try {
+    const parsed = JSON.parse(normalizedQuotes) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+    const entries = Object.entries(parsed).map(([gameKey, categories]) => [
+      String(gameKey),
+      Array.isArray(categories) ? categories.map((entry) => String(entry)) : [],
+    ]);
+    return Object.fromEntries(entries);
+  } catch {
+    return {};
+  }
+}
+
+export function formatProductsArray(products: ManualProductRecord[]) {
+  const json = JSON.stringify(products, null, 2);
+  return json.replace(/\n\]$/, "\n];");
+}
+
+export async function readManualProductsFile(): Promise<ManualProductsFile> {
+  const filePath = path.join(process.cwd(), "data/db/Product.ts");
+  const source = await fs.readFile(filePath, "utf8");
+  const { before, after, products } = extractProducts(source);
+  const gameCategories = extractGameCategories(source);
+
+  return { filePath, before, after, products, gameCategories };
+}
+
+function normalizeString(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizePoints(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const num = Number(trimmed);
+    return Number.isFinite(num) ? num : null;
+  }
+  return null;
+}
+
+async function hydrateOverridesFromFileIfEmpty() {
+  const countRow = (await query<{ count?: number }>("get", "select/manual_product_overrides_count")) || { count: 0 };
+  const count = Number(countRow?.count ?? 0);
+  if (Number.isFinite(count) && count > 0) {
+    return;
+  }
+
+  const { products } = await readManualProductsFile();
+  for (const product of products) {
+    const rawId = (product as ManualProductRecord).id;
+    const idNum = Number(typeof rawId === "string" ? rawId : (rawId as number));
+    if (!Number.isFinite(idNum)) continue;
+
+    const name = normalizeString((product as ManualProductRecord).name);
+    if (!name) continue;
+
+    const game = normalizeString((product as ManualProductRecord).game);
+    const faction = normalizeString((product as ManualProductRecord).faction);
+    const category = normalizeString((product as ManualProductRecord).category);
+    const points = normalizePoints((product as ManualProductRecord).points);
+    const hiddenValue = (product as ManualProductRecord).hidden === true ? 1 : null;
+
+    await query("run", "update/upsert_manual_product_override", [
+      idNum,
+      name,
+      game,
+      faction,
+      category,
+      typeof points === "number" && Number.isFinite(points) ? points : null,
+      hiddenValue,
+    ]);
+  }
+}
+
+let overridesReady: Promise<void> | null = null;
+async function ensureOverridesReady() {
+  if (!overridesReady) {
+    overridesReady = (async () => {
+      await query("run", "create/manual_product_overrides");
+      await hydrateOverridesFromFileIfEmpty();
+    })();
+  }
+
+  await overridesReady;
+}
+
+function rowToOverride(row: ManualProductOverrideRow): ManualProductOverride {
+  const override: ManualProductOverride = { id: String(row.product_id) };
+
+  if (typeof row.name === "string" && row.name.trim()) {
+    override.name = row.name.trim();
+  }
+
+  if (row.game !== undefined) {
+    override.game = row.game === null ? null : normalizeString(row.game);
+  }
+
+  if (row.faction !== undefined) {
+    override.faction = row.faction === null ? null : normalizeString(row.faction);
+  }
+
+  if (row.category !== undefined) {
+    override.category = row.category === null ? null : normalizeString(row.category);
+  }
+
+  if (row.points !== undefined) {
+    override.points = row.points === null ? null : Number(row.points);
+  }
+
+  if (row.hidden !== undefined) {
+    override.hidden = row.hidden === null ? null : Number(row.hidden) === 1;
+  }
+
+  return override;
+}
+
+async function loadOverridesMap() {
+  await ensureOverridesReady();
+  const rows = (await query<ManualProductOverrideRow[]>("all", "select/manual_product_overrides")) ?? [];
+  const map = new Map<string, ManualProductOverride>();
+  for (const row of rows) {
+    map.set(String(row.product_id), rowToOverride(row));
+  }
+  return map;
+}
+
+function applyOverride(base: ManualProductRecord, override: ManualProductOverride) {
+  const next: ManualProductRecord = { ...base };
+
+  if (override.name) {
+    next.name = override.name;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(override, "game")) {
+    if (override.game === null) {
+      delete next.game;
+    } else if (typeof override.game === "string") {
+      next.game = override.game;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(override, "faction")) {
+    if (override.faction === null) {
+      delete next.faction;
+    } else if (typeof override.faction === "string") {
+      next.faction = override.faction;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(override, "category")) {
+    if (override.category === null) {
+      delete next.category;
+    } else if (typeof override.category === "string") {
+      next.category = override.category;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(override, "points")) {
+    if (override.points === null || override.points === undefined) {
+      delete next.points;
+    } else {
+      next.points = override.points;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(override, "hidden")) {
+    if (override.hidden === null) {
+      delete next.hidden;
+    } else {
+      next.hidden = override.hidden;
+    }
+  }
+
+  return next;
+}
+
+async function buildFallbackRecords(overrides: Map<string, ManualProductOverride>, baseIds: Set<string>) {
+  const missing = Array.from(overrides.keys()).filter((id) => !baseIds.has(id));
+  if (missing.length === 0) return new Map<string, ManualProductRecord>();
+
+  const numericIds = missing
+    .map((id) => Number(id))
+    .filter((value) => Number.isFinite(value));
+
+  const placeholders = numericIds.map(() => "?").join(", ");
+  type ProductRow = { id: number; name: string };
+
+  const rows = placeholders
+    ? await query<ProductRow[]>(
+        "all",
+        `SELECT id, name FROM products WHERE id IN (${placeholders})`,
+        numericIds,
+      )
+    : [];
+
+  const fallbackMap = new Map<string, ManualProductRecord>();
+  for (const row of rows ?? []) {
+    if (!row) continue;
+    fallbackMap.set(String(row.id), { id: String(row.id), name: row.name });
+  }
+  return fallbackMap;
+}
+
+export async function loadManualProductsSnapshot() {
+  const { products: fileProducts, gameCategories } = await readManualProductsFile();
+  const overrides = await loadOverridesMap();
+
+  const baseIds = new Set<string>();
+  for (const product of fileProducts) {
+    const id = String((product as ManualProductRecord).id ?? "");
+    if (!id) continue;
+    baseIds.add(id);
+  }
+
+  const fallbackMap = await buildFallbackRecords(overrides, baseIds);
+
+  const merged: ManualProductRecord[] = [];
+  const seen = new Set<string>();
+
+  for (const product of fileProducts) {
+    const id = String((product as ManualProductRecord).id ?? "");
+    if (!id) continue;
+    const override = overrides.get(id);
+    const next = override ? applyOverride(product, override) : product;
+    merged.push(next);
+    seen.add(id);
+  }
+
+  for (const [id, override] of overrides.entries()) {
+    if (seen.has(id)) continue;
+    const fallback = fallbackMap.get(id) ?? { id };
+    merged.push(applyOverride(fallback, override));
+  }
+
+  return { products: merged, gameCategories };
+}
+
+export async function loadManualProductById(id: string) {
+  const snapshot = await loadManualProductsSnapshot();
+  const entry = snapshot.products.find((item) => String(item.id) === String(id));
+  if (entry) {
+    return { ...entry } as ManualProductRecord;
+  }
+
+  const row = await query<{ id: number; name: string } | undefined>(
+    "get",
+    "select/product_id",
+    [Number(id)],
+  );
+
+  if (row && row.id) {
+    return { id: String(row.id), name: row.name } as ManualProductRecord;
+  }
+
+  return null;
+}
+
+export async function saveManualProductOverride(id: string, record: ManualProductRecord) {
+  await ensureOverridesReady();
+
+  const idNum = Number(id);
+  if (!Number.isFinite(idNum)) {
+    throw new Error("invalid-id");
+  }
+
+  const name = normalizeString(record.name);
+  if (!name) {
+    throw new Error("invalid-name");
+  }
+
+  const game = normalizeString(record.game);
+  const faction = normalizeString(record.faction);
+  const category = normalizeString(record.category);
+  const points = normalizePoints(record.points);
+  const hidden = record.hidden === true ? 1 : record.hidden === false ? 0 : null;
+
+  await query("run", "update/upsert_manual_product_override", [
+    idNum,
+    name,
+    game,
+    faction,
+    category,
+    Number.isFinite(points) ? points : null,
+    hidden,
+  ]);
+
+  return loadManualProductById(String(idNum));
+}

--- a/src/app/product/[id]/ProductEditForm.tsx
+++ b/src/app/product/[id]/ProductEditForm.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface ProductEditFormProps {
+  productId: string;
+  initialValues: {
+    name?: string | null;
+    game: string;
+    faction: string;
+    category: string;
+    points: number | null;
+    hidden?: boolean | null;
+  };
+  gameCategories: Record<string, string[]>;
+}
+
+type NormalizedValues = {
+  name: string;
+  game: string;
+  faction: string;
+  category: string;
+  points: string;
+  hidden: boolean;
+};
+
+type StatusState =
+  | { type: "idle" }
+  | { type: "saving" }
+  | { type: "success"; message: string }
+  | { type: "error"; message: string };
+
+const normalizeInitialValues = (values: ProductEditFormProps["initialValues"]): NormalizedValues => ({
+  name: typeof values.name === "string" ? values.name.trim() : "",
+  game: values.game ?? "",
+  faction: values.faction ?? "",
+  category: values.category ?? "",
+  points:
+    values.points !== null && values.points !== undefined && Number.isFinite(values.points)
+      ? String(values.points)
+      : "",
+  hidden: values.hidden === true,
+});
+
+export default function ProductEditForm({ productId, initialValues, gameCategories }: ProductEditFormProps) {
+  const router = useRouter();
+  const normalizedInitial = useMemo(() => normalizeInitialValues(initialValues), [initialValues]);
+
+  const [baseValues, setBaseValues] = useState<NormalizedValues>(normalizedInitial);
+  const [name, setName] = useState(normalizedInitial.name);
+  const [game, setGame] = useState(normalizedInitial.game);
+  const [faction, setFaction] = useState(normalizedInitial.faction);
+  const [category, setCategory] = useState(normalizedInitial.category);
+  const [points, setPoints] = useState(normalizedInitial.points);
+  const [hidden, setHidden] = useState(normalizedInitial.hidden);
+  const [status, setStatus] = useState<StatusState>({ type: "idle" });
+
+  useEffect(() => {
+    setBaseValues(normalizedInitial);
+    setName(normalizedInitial.name);
+    setGame(normalizedInitial.game);
+    setFaction(normalizedInitial.faction);
+    setCategory(normalizedInitial.category);
+    setPoints(normalizedInitial.points);
+    setHidden(normalizedInitial.hidden);
+  }, [normalizedInitial]);
+
+  const gameOptions = useMemo(
+    () => Object.keys(gameCategories || {}).sort((a, b) => a.localeCompare(b)),
+    [gameCategories],
+  );
+  const categoryOptions = useMemo(() => {
+    const key = game.trim();
+    const options = gameCategories?.[key] ?? [];
+    if (!Array.isArray(options)) return [];
+    return Array.from(new Set(options.map((entry) => String(entry)))).sort((a, b) => a.localeCompare(b));
+  }, [game, gameCategories]);
+
+  const isDirty =
+    name !== baseValues.name ||
+    game !== baseValues.game ||
+    faction !== baseValues.faction ||
+    category !== baseValues.category ||
+    points !== baseValues.points ||
+    hidden !== baseValues.hidden;
+
+  const gameDatalistId = `game-options-${productId}`;
+  const categoryDatalistId = `category-options-${productId}`;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (status.type === "saving") return;
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setStatus({ type: "error", message: "Name is required." });
+      return;
+    }
+
+    setStatus({ type: "saving" });
+
+    const payload = {
+      name: trimmedName,
+      game,
+      faction,
+      category,
+      points,
+      hidden,
+    };
+
+    try {
+      const res = await fetch(`/api/admin/products/${productId}/metadata`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        let message = "Failed to save changes.";
+        try {
+          const data = await res.json();
+          if (typeof data?.error === "string" && data.error.trim()) {
+            message = data.error.trim();
+          }
+        } catch {}
+        setStatus({ type: "error", message });
+        return;
+      }
+
+      let updated = normalizedInitial;
+      try {
+        const data = await res.json();
+        if (data?.product) {
+          const next = normalizeInitialValues({
+            name: typeof data.product.name === "string" ? data.product.name : normalizedInitial.name,
+            game: typeof data.product.game === "string" ? data.product.game : "",
+            faction: typeof data.product.faction === "string" ? data.product.faction : "",
+            category: typeof data.product.category === "string" ? data.product.category : "",
+            points:
+              typeof data.product.points === "number" && Number.isFinite(data.product.points)
+                ? data.product.points
+                : null,
+            hidden: data.product.hidden === true,
+          });
+          updated = next;
+        }
+      } catch {}
+
+      setBaseValues(updated);
+      setName(updated.name);
+      setGame(updated.game);
+      setFaction(updated.faction);
+      setCategory(updated.category);
+      setPoints(updated.points);
+      setHidden(updated.hidden);
+      setStatus({ type: "success", message: "Saved changes." });
+      router.refresh();
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error && error.message ? error.message : "Failed to save changes.";
+      setStatus({ type: "error", message });
+    }
+  }
+
+  function handleReset() {
+    setName(baseValues.name);
+    setGame(baseValues.game);
+    setFaction(baseValues.faction);
+    setCategory(baseValues.category);
+    setPoints(baseValues.points);
+    setHidden(baseValues.hidden);
+    setStatus({ type: "idle" });
+  }
+
+  const isSaving = status.type === "saving";
+  const isNameValid = Boolean(name.trim());
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50/80 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/60">
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">Edit metadata</h2>
+        <button
+          type="button"
+          className="text-xs font-medium text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 disabled:opacity-60"
+          onClick={handleReset}
+          disabled={!isDirty || isSaving}
+        >
+          Reset
+        </button>
+      </div>
+      <p className="mb-3 text-xs text-slate-500 dark:text-slate-400">
+        Leave a field blank to clear it. Suggestions are provided where available.
+      </p>
+      <div
+        className={`mb-4 rounded-md border px-3 py-2 text-[0.7rem] font-semibold tracking-[0.28em]
+          ${hidden
+            ? "border-amber-500/60 bg-amber-100/80 text-amber-700 dark:border-amber-400/50 dark:bg-amber-500/10 dark:text-amber-200"
+            : "border-emerald-500/50 bg-emerald-100/80 text-emerald-700 dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-200"}`}
+        role="status"
+        aria-live="polite"
+      >
+        {hidden ? "Hidden from public pages" : "Visible to everyone"}
+      </div>
+      <form onSubmit={handleSubmit} className="grid gap-3">
+        <div className="grid gap-1">
+          <label htmlFor={`name-${productId}`} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            Name
+          </label>
+          <input
+            id={`name-${productId}`}
+            name="name"
+            placeholder="Enter product name"
+            className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            autoComplete="off"
+            required
+          />
+        </div>
+
+        <div className="grid gap-1">
+          <label htmlFor={`game-${productId}`} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            Universe
+          </label>
+          <input
+            id={`game-${productId}`}
+            name="game"
+            list={gameDatalistId}
+            placeholder="e.g. warhammer40k"
+            className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+            value={game}
+            onChange={(event) => setGame(event.target.value)}
+            autoComplete="off"
+          />
+          <datalist id={gameDatalistId}>
+            {gameOptions.map((option) => (
+              <option key={option} value={option} />
+            ))}
+          </datalist>
+        </div>
+
+        <div className="grid gap-1">
+          <label htmlFor={`faction-${productId}`} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            Faction
+          </label>
+          <input
+            id={`faction-${productId}`}
+            name="faction"
+            placeholder="Enter faction"
+            className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+            value={faction}
+            onChange={(event) => setFaction(event.target.value)}
+            autoComplete="off"
+          />
+        </div>
+
+        <div className="grid gap-1">
+          <label htmlFor={`category-${productId}`} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            Category
+          </label>
+          <input
+            id={`category-${productId}`}
+            name="category"
+            list={categoryDatalistId}
+            placeholder="Enter category"
+            className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+            value={category}
+            onChange={(event) => setCategory(event.target.value)}
+            autoComplete="off"
+          />
+          <datalist id={categoryDatalistId}>
+            {categoryOptions.map((option) => (
+              <option key={option} value={option} />
+            ))}
+          </datalist>
+        </div>
+
+        <div className="grid gap-1">
+          <label htmlFor={`points-${productId}`} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            Points
+          </label>
+          <input
+            id={`points-${productId}`}
+            name="points"
+            type="number"
+            min={0}
+            step="any"
+            placeholder="Leave blank to clear"
+            className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+            value={points}
+            onChange={(event) => setPoints(event.target.value)}
+          />
+        </div>
+
+        <div className="rounded-md border border-slate-200/80 bg-white/90 p-3 text-sm text-slate-700 shadow-sm transition dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-100">
+          <label className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              className="mt-1 h-4 w-4 rounded border-slate-400 text-slate-900 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-800"
+              checked={hidden}
+              onChange={(event) => setHidden(event.target.checked)}
+              disabled={isSaving}
+            />
+            <span className="flex-1 leading-relaxed">
+              Hide this product from public search and comparison pages. Hidden products remain accessible to admins with the
+              direct link so you can unhide them later.
+            </span>
+          </label>
+        </div>
+
+        <div className="flex items-center gap-2" aria-live="polite">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-70"
+            disabled={isSaving || !isNameValid}
+          >
+            {isSaving ? "Saving…" : "Save changes"}
+          </button>
+          {status.type === "success" && (
+            <span className="text-sm font-medium text-emerald-600 dark:text-emerald-400">{status.message}</span>
+          )}
+          {status.type === "error" && (
+            <span className="text-sm font-medium text-red-600 dark:text-red-400">{status.message}</span>
+          )}
+        </div>
+      </form>
+      <div className="mt-4 flex justify-end">
+        <a
+          href="/api/admin/products/manual/download"
+          className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+        >
+          Download Product.ts
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -3,6 +3,10 @@ import { query } from "@/lib/sql";
 import fs from "fs";
 import path from "path";
 import Script from "next/script";
+import { headers } from "next/headers";
+import { isAuthorizedAdmin } from "@/app/lib/auth";
+import { loadManualProductsSnapshot } from "@/app/lib/manual-products";
+import ProductEditForm from "./ProductEditForm";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -13,6 +17,19 @@ type PriceRow = {
   seller_name: string;
   price: number | null;
   link: string | null;
+};
+
+type ManualProduct = {
+  id: string;
+  name?: string;
+  game?: string | null;
+  faction?: string | null;
+  category?: string | null;
+  points?: number | string | null;
+  description?: string | null;
+  image?: string | null;
+  hidden?: boolean | null;
+  [key: string]: unknown;
 };
 
 // Format like "$100 AUD"
@@ -51,12 +68,17 @@ export default async function ProductPage({
   const prices = (await query("all", "select/display_prices", [product.id])) as PriceRow[];
 
   // Hand-edited metadata
-  let manual: any = null;
+  let manual: ManualProduct | null = null;
+  let manualGameCategories: Record<string, string[]> = {};
   try {
-    const mod: any = await import("../../../../data/db/Product");
-    const list: any[] = mod?.Products ?? mod?.default ?? [];
-    manual = Array.isArray(list) ? list.find((p) => p.id === String(product.id)) : null;
-  } catch {}
+    const { products, gameCategories } = await loadManualProductsSnapshot();
+    const entry = products.find((p) => String(p.id) === String(product.id)) ?? null;
+    manual = (entry ?? null) as ManualProduct | null;
+    manualGameCategories = gameCategories;
+  } catch {
+    manual = null;
+    manualGameCategories = {};
+  }
 
   // Image fallback (use public/images/product/<filename> from Product.tsx)
   const PLACEHOLDER = "/logo/logo.png";
@@ -71,14 +93,43 @@ export default async function ProductPage({
     }
   }
 
-  const faction = manual?.faction ?? "—";
-  const game = manual?.game ?? "—";
-  const category = manual?.category ?? "—";
-  const points = typeof manual?.points === "number" ? manual.points : null;
+  const manualGame = typeof manual?.game === "string" ? manual.game.trim() : "";
+  const manualFaction = typeof manual?.faction === "string" ? manual.faction.trim() : "";
+  const manualCategory = typeof manual?.category === "string" ? manual.category.trim() : "";
+  const manualName = typeof manual?.name === "string" ? manual.name.trim() : "";
+  const rawPoints = manual?.points;
+  const manualPoints =
+    typeof rawPoints === "number" && Number.isFinite(rawPoints)
+      ? rawPoints
+      : typeof rawPoints === "string" && rawPoints.trim() && Number.isFinite(Number(rawPoints.trim()))
+      ? Number(rawPoints.trim())
+      : null;
+  const manualHidden = manual?.hidden === true;
+  const displayName = manualName || product.name;
+  const faction = manualFaction || "—";
+  const game = manualGame || "—";
+  const category = manualCategory || "—";
+  const points = manualPoints;
   const description =
     typeof manual?.description === "string" && manual.description.trim()
       ? manual.description.trim()
       : null;
+
+  const headerList = await headers();
+  const adminAuthHeader = headerList.get("authorization");
+  const isAdmin = isAuthorizedAdmin(adminAuthHeader);
+  const gameCategoriesForClient = manualGameCategories;
+
+  if (manualHidden && !isAdmin) {
+    return (
+      <div className="max-w-3xl mx-auto p-6">
+        <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100">Product hidden</h1>
+        <p className="mt-2 text-slate-700 dark:text-slate-300">
+          This product is not currently visible on PriceHammer. Please check back later or ask an admin to unhide it.
+        </p>
+      </div>
+    );
+  }
 
   // Initial sort on the server; JS will handle button toggles without reload
   const initiallySorted = (prices ?? []).slice().sort((a, b) => {
@@ -102,6 +153,15 @@ export default async function ProductPage({
                         bg-white/95 dark:bg-slate-900/95
                         supports-[backdrop-filter]:backdrop-blur-sm p-6">
 
+          {manualHidden && isAdmin && (
+            <div className="rounded-lg border border-amber-500/50 bg-amber-50/80 p-4 text-amber-800 shadow-sm dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-100">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.32em] text-amber-700 dark:text-amber-200">Hidden product</h2>
+              <p className="mt-2 text-sm text-amber-700/90 dark:text-amber-100/90">
+                This product is hidden from public listings. Use the toggle in the edit panel to make it visible again.
+              </p>
+            </div>
+          )}
+
           <div className="flex gap-6 items-start">
             {/* Clickable image (opens modal) */}
             <button
@@ -114,12 +174,12 @@ export default async function ProductPage({
                          focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500"
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={imgSrc} alt={product.name} className="object-contain w-full h-full" />
+              <img src={imgSrc} alt={displayName} className="object-contain w-full h-full" />
             </button>
 
             <div className="flex-1">
               <div className="flex items-start justify-between gap-3">
-                <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-50">{product.name}</h1>
+                <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-50">{displayName}</h1>
 
                 {/* Share / Copy */}
                 <button
@@ -129,18 +189,35 @@ export default async function ProductPage({
                              bg-white hover:bg-slate-50
                              dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700
                              text-slate-800 dark:text-slate-100"
-                  data-title={product.name}
+                  data-title={displayName}
                 >
                   Share
                 </button>
               </div>
 
               <div className="text-slate-700 dark:text-slate-200 mt-2 space-y-0.5">
-                <div><span className="font-semibold">Game:</span> {game}</div>
+                <div><span className="font-semibold">Universe:</span> {game}</div>
                 <div><span className="font-semibold">Faction:</span> {faction}</div>
                 <div><span className="font-semibold">Category:</span> {category}</div>
                 <div><span className="font-semibold">Points:</span> {points ?? "—"}</div>
               </div>
+
+              {isAdmin && (
+                <div className="mt-4">
+                  <ProductEditForm
+                    productId={String(product.id)}
+                    initialValues={{
+                      name: displayName,
+                      game: manualGame,
+                      faction: manualFaction,
+                      category: manualCategory,
+                      points: manualPoints,
+                      hidden: manualHidden,
+                    }}
+                    gameCategories={gameCategoriesForClient}
+                  />
+                </div>
+              )}
 
               {description && (
                 <p className="mt-4 text-slate-700 dark:text-slate-200 leading-relaxed">
@@ -238,7 +315,7 @@ export default async function ProductPage({
                           title="Report an incorrect price or broken link"
                           data-link={r.link ?? ""}
                           data-seller={r.seller_name}
-                          data-product={product.name}
+                          data-product={displayName}
                           disabled={!r.link}
                         >
                           Report
@@ -285,7 +362,7 @@ export default async function ProductPage({
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={imgSrc}
-              alt={product.name}
+              alt={displayName}
               className="w-full h-auto max-h-[85vh] object-contain rounded-lg shadow-2xl bg-white dark:bg-slate-900"
             />
           </div>


### PR DESCRIPTION
## Summary
- add a manual_product_overrides table and helper queries so metadata edits survive server restarts
- refactor the admin metadata API and product loaders to read and write overrides from SQLite instead of data/db/Product.ts
- expose a secured download endpoint and UI link so admins can grab the current Product.ts snapshot when needed

## Testing
- npm run lint *(fails: repository already has numerous pre-existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cadb68148330ac520db2eb086381